### PR TITLE
Rename "reasonable fee" to "fair fee", redefine, and lower cap

### DIFF
--- a/license.md
+++ b/license.md
@@ -88,10 +88,10 @@ The **licensor** is the individual or entity offering these terms, and the **sof
 
 **Use** means anything you do with the software requiring one of your licenses.
 
-A **fair commercial license** permits the recipient to do everything that these terms allows companies qualifying under [Small Business](#small-business) to do, for a reasonable fee, without additional unreasonable terms or terms that discriminate against particular licensees.  A fair commercial license may be perpetual or for a term, and may or may not cover new versions of the software.
+A **fair commercial license** permits the recipient to do everything that these terms allows companies qualifying under [Small Business](#small-business) to do, for a fair fee, without additional unreasonable terms or terms that discriminate against particular licensees.  A fair commercial license may be perpetual or for a term, and may or may not cover new versions of the software.
 
-A **reasonable fee** for a fair commercial license is not more than:
+A **fair fee** is a fair market price for a fair commercial license.  If the licensor advertises a fee for generally available fair commercial licenses, and more than one unaffiliated customer has paid that price in the past year, that is a fair fee.  However, a fair fee may not be more than:
 
-1.  on an annual basis, the number of software developers who have made substantial contributions to the software in the last four years times 1.25 times the annual wage for software developers reported in the most recent Bureau of Labor Statistics Occupational Employment Statistics survey
+1.  on an annual basis, the number of software developers who have made substantial technical contributions to the software in the last four years times 0.25 times the annual wage for software developers reported in the most recent Bureau of Labor Statistics Occupational Employment Statistics survey
 
-2.  on a perpetual basis, two times a reasonable fee on an annual basis
+2.  on a perpetual basis, two times a fair fee on an annual basis


### PR DESCRIPTION
This PR changes the defined term from "reasonable fee" to "fair fee", and makes a number of changes to the definition:

1. Define first in terms of fair market price.

2. Clarify that if the licensor has a published list price, that fee is fair.

3. But qualify all of that with a limit based on BLS wage data.

4.  Lower the wage-based cap to the number of active developers time _one quarter_ of the average wage.

I do think number of active devs times 1.25 times the average wage would tend to overprice. Our dollar thresholds for "small business" are a million dollars. The average wage is north of $100k, or 10% of $1m.