### PR TITLE
Reduce headcount threshold to twenty

### DIFF
--- a/license.md
+++ b/license.md
@@ -28,7 +28,7 @@ Use by any charitable organization, educational institution, public research org
 
 You may use the software for the benefit of your company if it meets all these criteria:
 
-1.  had fewer than 100 total individuals working as employees and independent contractors at all times during the last tax year
+1.  had fewer than 20 total individuals working as employees and independent contractors at all times during the last tax year
 
 2.  earned less than 1,000,000 USD (2019) total revenue in the last tax year
 


### PR DESCRIPTION
A number of readers have commented that the headcount-based threshold for small business status seems out of proportion with the revenue and capital figures. See, e.g.:

- https://news.ycombinator.com/item?id=29924637
- https://forum.artlessdevices.com/t/headcount-in-big-time-license/324

All the numbers together needn't paint a consistent picture of a single hypothetical company, so much as work together to keep business who should do a deal from skating by under the free grant. The headcount figure also takes into account contractors and part-timers, not just full-time employees. But I've become convinced it would be worth reducing the headcount figure.

The general call is still that it's better to "hard-code" one good-enough number into the terms than to introduce the complexity of parameterization or a fill-in-the-blank. Software folks tend to like those concepts in the abstract, but in practice they've proved complicated and confusing for license terms. See, for example, the Fair Source Lciense.

So the goal here is getting a number that's "good enough" for a very broad swathe of potential licensors. 100 was a nice round power of ten, like $1m figures for revenue and capital. But my instincts tell me 10 is probably too low in many cases, especially since we're potentially counting part-time contractors.