### PR TITLE
FRAND: Explicitly prohibit exploitation of adoption

### DIFF
--- a/license.md
+++ b/license.md
@@ -50,7 +50,7 @@ If this software includes an address for the licensor or an agent of the licenso
 
 ## Fair, Reasonable, and Nondiscriminatory Terms
 
-Fair, reasonable, and nondiscriminatory terms may not exploit the fact that you adopted or invested in the software in reliance on these terms.  They may license the software perpetually or for a term, and may or may not cover new versions of the software.  If the licensor advertises license terms and a pricing structure for generally available commercial licenses, the licensor proposes license terms and a price as advertised, and a customer not affiliated with the licensor has bought a commercial commercial license for the software on substantially equivalent terms in the past year, the proposal is fair, reasonable, and nondiscriminatory.
+Fair, reasonable, and nondiscriminatory terms may not exploit the fact that you have come to depend on the software in reliance on these terms.  They may license the software perpetually or for a term, and may or may not cover new versions of the software.  If the licensor advertises license terms and a pricing structure for generally available commercial licenses, the licensor proposes license terms and a price as advertised, and a customer not affiliated with the licensor has bought a commercial commercial license for the software on substantially equivalent terms in the past year, the proposal is fair, reasonable, and nondiscriminatory.
 
 ## Copyright License
 

--- a/license.md
+++ b/license.md
@@ -50,7 +50,7 @@ If this software includes an address for the licensor or an agent of the licenso
 
 ## Fair, Reasonable, and Nondiscriminatory Terms
 
-Fair, reasonable, and nondiscriminatory terms may license the software perpetually or for a term, and may or may not cover new versions of the software.  If the licensor advertises license terms and a pricing structure for generally available commercial licenses, the licensor proposes license terms and a price as advertised, and a customer not affiliated with the licensor has bought a commercial commercial license for the software on substantially equivalent terms in the past year, the proposal is fair, reasonable, and nondiscriminatory.
+Fair, reasonable, and nondiscriminatory terms may not exploit the fact that you adopted or invested in the software in reliance on these terms.  They may license the software perpetually or for a term, and may or may not cover new versions of the software.  If the licensor advertises license terms and a pricing structure for generally available commercial licenses, the licensor proposes license terms and a price as advertised, and a customer not affiliated with the licensor has bought a commercial commercial license for the software on substantially equivalent terms in the past year, the proposal is fair, reasonable, and nondiscriminatory.
 
 ## Copyright License
 

--- a/license.md
+++ b/license.md
@@ -50,7 +50,7 @@ If this software includes an address for the licensor or an agent of the licenso
 
 ## Fair, Reasonable, and Nondiscriminatory Terms
 
-Fair, reasonable, and nondiscriminatory terms may not exploit the fact that you have come to depend on the software in reliance on these terms.  They may license the software perpetually or for a term, and may or may not cover new versions of the software.  If the licensor advertises license terms and a pricing structure for generally available commercial licenses, the licensor proposes license terms and a price as advertised, and a customer not affiliated with the licensor has bought a commercial commercial license for the software on substantially equivalent terms in the past year, the proposal is fair, reasonable, and nondiscriminatory.
+Fair, reasonable, and nondiscriminatory terms may not exploit the fact that you have come to depend on the software in reliance on these terms.  Fair, reasonable, and nondiscriminatory terms may license the software perpetually or for a term, and may or may not cover new versions of the software.  If the licensor advertises license terms and a pricing structure for generally available commercial licenses, the licensor proposes license terms and a price as advertised, and a customer not affiliated with the licensor has bought a commercial commercial license for the software on substantially equivalent terms in the past year, the proposal is fair, reasonable, and nondiscriminatory.
 
 ## Copyright License
 


### PR DESCRIPTION
This PR tries to make the _purpose_ of the reuse of the "FRAND" concept more explicit, by making clear that the licensor can't exploit a user's adoption of their software when they were covered for free use.

Standards lure would-be implementers into practicing essential patents.  Big Time could lures small-business users into adopting software for free before the eventually grow larger and need to buy licenses.
